### PR TITLE
add bluesky to inbound/outbound services

### DIFF
--- a/Sources/DiasporaNodeInfo/2.0/2.0-InboundSite.swift
+++ b/Sources/DiasporaNodeInfo/2.0/2.0-InboundSite.swift
@@ -10,6 +10,7 @@ public extension DiasporaNodeInfo.v2_0 {
     /// The third party sites this server can retrieve messages from for combined display with regular traffic.
     enum InboundSite: String, Codable {
         case atom1_0 = "atom1.0"
+        case bluesky
         case gnusocial
         case imap
         case pnut

--- a/Sources/DiasporaNodeInfo/2.0/2.0-OutboundSite.swift
+++ b/Sources/DiasporaNodeInfo/2.0/2.0-OutboundSite.swift
@@ -11,6 +11,7 @@ public extension DiasporaNodeInfo.v2_0 {
     enum OutboundSite: String, Codable {
         case atom1_0 = "atom1.0"
         case blogger
+        case bluesky
         case buddycloud
         case diaspora
         case dreamwidth


### PR DESCRIPTION
I ran into a bunch of friendica sites that include bluesky in services, e.g.

```
{
    "version": "2.0",
    "software": {
        "name": "friendica",
        "version": "2024.03-1557"
    },
    "protocols": [
        "dfrn",
        "activitypub",
        "diaspora",
        "ostatus"
    ],
    "services": {
        "inbound": [
            "bluesky",
            "gnusocial",
            "pumpio",
            "atom1.0",
            "rss2.0",
            "imap"
        ],
        "outbound": [
            "bluesky",
            "gnusocial",
            "libertree",
            "pumpio",
            "smtp",
            "tumblr",
            "wordpress",
            "atom1.0"
        ]
    },
    "usage": {
        "users": {
            "total": 558,
            "activeHalfyear": 216,
            "activeMonth": 113
        },
        "localPosts": 5266,
        "localComments": 14349
    },
    "openRegistrations": true,
    "metadata": {
        "nodeName": "Friendica Open Social Space",
        "explicitContent": false
    }
}